### PR TITLE
modify the json decoder to support json array when looking for a timestamp

### DIFF
--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JitneyTimestampDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JitneyTimestampDecoder.java
@@ -1,0 +1,119 @@
+package com.linkedin.camus.etl.kafka.coders;
+
+import java.nio.charset.Charset;
+import java.text.SimpleDateFormat;
+import java.util.Properties;
+
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import net.minidev.json.JSONValue;
+
+import org.apache.log4j.Logger;
+
+import com.linkedin.camus.coders.CamusWrapper;
+import com.linkedin.camus.coders.MessageDecoder;
+
+
+/**
+ * MessageDecoder class that will work with Airbnb Jitney message format, which is an json array
+ * with two elements, the one element is the Jitney message meta data, and the second element is
+ * payload, the as below:
+ * [{"eventType":"example_event_type",
+ *   "id":"example_id",
+ *   "createdAt":1428000472668,
+ *   "sequenceOrigin":1428000397254,
+ *   "sequenceNumber":3,
+ *   "sourceName":"example_source",
+ *   "sourceIpAddress":"127.0.0.1",
+ *   "sourceHostname":"localhost",
+ *   "version":1},
+ *   {"example_payload":
+ *     {"userId":1,
+ *     "activityType":"test_activity",
+ *     ...
+ *     },
+ *     "eventType":"example_event_type"
+ *   }]
+ *
+ * This decoder converts the payload into a JSON array, and look for a field named 'createdAt' in
+ * the each of the JSON object, then set the CamusWrapper's timestamp property to the record's
+ * timestamp. If the JSON does not have a timestamp, then System.currentTimeMillis() will be used.
+ * The timestamp will be used for placing the message into the correct partition in kafka.
+ * This MessageDecoder returns a CamusWrapper that works with Strings payloads.
+ */
+public class JitneyTimestampDecoder extends MessageDecoder<byte[], String> {
+  private static org.apache.log4j.Logger log = Logger.getLogger(JsonStringMessageDecoder.class);
+
+  // Property for format of timestamp in JSON timestamp field.
+  public  static final String CAMUS_MESSAGE_TIMESTAMP_FORMAT = "camus.message.timestamp.format";
+  public  static final String DEFAULT_TIMESTAMP_FORMAT       = "[dd/MMM/yyyy:HH:mm:ss Z]";
+
+  // Property for the JSON field name of the timestamp.
+  public  static final String CAMUS_MESSAGE_TIMESTAMP_FIELD  = "camus.message.timestamp.field";
+  public  static final String DEFAULT_TIMESTAMP_FIELD        = "createdAt";
+
+  private String timestampFormat;
+  private String timestampField;
+
+  @Override
+  public void init(Properties props, String topicName) {
+    this.props     = props;
+    this.topicName = topicName;
+
+    timestampFormat = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FORMAT, DEFAULT_TIMESTAMP_FORMAT);
+    timestampField  = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FIELD,  DEFAULT_TIMESTAMP_FIELD);
+  }
+
+  @Override
+  public CamusWrapper<String> decode(byte[] payload) {
+    long       timestamp = 0;
+    String     payloadString;
+    // Need to specify Charset because the default might not be UTF-8.
+    // Bug fix for https://jira.airbnb.com:8443/browse/PRODUCT-5551.
+    payloadString =  new String(payload, Charset.forName("UTF-8"));
+
+    // Parse the payload into a JsonObject.
+    try {
+      Object obj = JSONValue.parse(payloadString);
+      if (obj instanceof JSONObject) {
+        timestamp = getTimestamp((JSONObject) obj);
+      } else if (obj instanceof JSONArray) {
+        for (Object elem : (JSONArray) obj) {
+          timestamp = getTimestamp((JSONObject) elem);
+          if (timestamp != 0L) {
+            break;
+          }
+        }
+      }
+    } catch (RuntimeException e) {
+      log.error("Caught exception while parsing JSON string '" + payloadString + "'.");
+      throw new RuntimeException(e);
+    }
+
+    // If timestamp wasn't set in the above block,
+    // then set it to current time.
+    if (timestamp == 0) {
+      log.warn("Couldn't find or parse timestamp field '" + timestampField + "' in JSON message, defaulting to current time.");
+      timestamp = System.currentTimeMillis();;
+    }
+
+    return new CamusWrapper<String>(payloadString, timestamp);
+  }
+
+  private long getTimestamp(JSONObject jsonObject) {
+    // Attempt to read and parse the timestamp element into a long.
+    if (jsonObject.get(timestampField) != null) {
+      Object ts = jsonObject.get(timestampField);
+      if (ts instanceof String) {
+        try {
+          return new SimpleDateFormat(timestampFormat).parse((String)ts).getTime();
+        } catch (Exception e) {
+          log.error("Could not parse timestamp '" + ts + "' while decoding JSON message.");
+        }
+      } else if (ts instanceof Long) {
+        return (Long)ts;
+      }
+    }
+    return 0L;
+  }
+}

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
@@ -4,6 +4,7 @@ import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.util.Properties;
 
+import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONValue;
 
@@ -48,41 +49,52 @@ public class JsonStringMessageDecoder extends MessageDecoder<byte[], String> {
 	public CamusWrapper<String> decode(byte[] payload) {
 		long       timestamp = 0;
 		String     payloadString;
-                JSONObject jobj;
     // Need to specify Charset because the default might not be UTF-8.
     // Bug fix for https://jira.airbnb.com:8443/browse/PRODUCT-5551.
 		payloadString =  new String(payload, Charset.forName("UTF-8"));
 
 		// Parse the payload into a JsonObject.
 		try {
-                        jobj = (JSONObject) JSONValue.parse(payloadString);
+      Object obj = JSONValue.parse(payloadString);
+      if (obj instanceof JSONObject) {
+        timestamp = getTimestamp((JSONObject) obj);
+      } else if (obj instanceof JSONArray) {
+        for (Object elem : (JSONArray) obj) {
+          timestamp = getTimestamp((JSONObject) elem);
+          if (timestamp != 0L) {
+            break;
+          }
+        }
+      }
 		} catch (RuntimeException e) {
 			log.error("Caught exception while parsing JSON string '" + payloadString + "'.");
 			throw new RuntimeException(e);
 		}
 
-		// Attempt to read and parse the timestamp element into a long.
-		if (jobj.get(timestampField) != null) {
-			Object ts = jobj.get(timestampField);
-			if (ts instanceof String) {
-				try {
-					timestamp = new SimpleDateFormat(timestampFormat).parse((String)ts).getTime();
-				} catch (Exception e) {
-					log.error("Could not parse timestamp '" + ts + "' while decoding JSON message.");
-				}
-			} else if (ts instanceof Long) {
-				timestamp = (Long)ts;
-			}
-		}
-
 		// If timestamp wasn't set in the above block,
 		// then set it to current time.
-		final long now = System.currentTimeMillis();
 		if (timestamp == 0) {
 			log.warn("Couldn't find or parse timestamp field '" + timestampField + "' in JSON message, defaulting to current time.");
-			timestamp = now;
+			timestamp = System.currentTimeMillis();;
 		}
 
 		return new CamusWrapper<String>(payloadString, timestamp);
 	}
+
+  private long getTimestamp(JSONObject jsonObject) {
+    // Attempt to read and parse the timestamp element into a long.
+    if (jsonObject.get(timestampField) != null) {
+      Object ts = jsonObject.get(timestampField);
+      if (ts instanceof String) {
+        try {
+          return new SimpleDateFormat(timestampFormat).parse((String)ts).getTime();
+        } catch (Exception e) {
+          log.error("Could not parse timestamp '" + ts + "' while decoding JSON message.");
+        }
+      } else if (ts instanceof Long) {
+        return (Long)ts;
+      }
+    }
+    return 0L;
+  }
 }


### PR DESCRIPTION
@krishnap @ericlevine 
Modify the json decoder to support json array when looking for a timestamp
Currently jitney message is in this format
[{"eventType":"session-activity","id":"ae86fa9d-0332-4fb1-9560-4d020bd2eec2"...},{"sessionActivity":{"userId":1,"activityType":"test_activity","sessionId":"session_id"},"eventType":"session-activity"}]
basically an array of 2 json objects, the first one is the jitney meta data and the second one is the session activity payload, the current code is assuming the message is a json object per message and need to updated to support JSONArray
