### PR TITLE
Add config param for overriding etl topic output dir

### DIFF
--- a/camus-api/pom.xml
+++ b/camus-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camus-api</artifactId>

--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.linkedin.camus</groupId>
         <artifactId>camus-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camus-etl-kafka</artifactId>

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/coders/DefaultPartitioner.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/coders/DefaultPartitioner.java
@@ -24,7 +24,13 @@ public class DefaultPartitioner extends Partitioner {
     @Override
     public String generatePartitionedPath(JobContext context, String topic, String brokerId, int partitionId, String encodedPartition) {
         StringBuilder sb = new StringBuilder();
-        sb.append(topic).append("/");
+
+        // If etl.destination.path.topic.dir.override is set, put all topic outputs under that
+        // dir. Otherwise, use topic name.
+        String topicOverrideDir = EtlMultiOutputFormat.getDestPathTopicDirOverride(context);
+        String topicDir = (topicOverrideDir != null) ? topicOverrideDir : topic;
+        sb.append(topicDir).append("/");
+
         sb.append(EtlMultiOutputFormat.getDestPathTopicSubDir(context)).append("/");
         DateTime bucket = new DateTime(Long.valueOf(encodedPartition));
         sb.append(bucket.toString(OUTPUT_DATE_FORMAT));

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputFormat.java
@@ -31,6 +31,8 @@ import com.linkedin.camus.etl.kafka.common.EtlKey;
 
 public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
     public static final String ETL_DESTINATION_PATH = "etl.destination.path";
+    public static final String ETL_DESTINATION_PATH_TOPIC_DIR_OVERRIDE = "etl.destination.path.topic.dir.override";
+
     public static final String ETL_DESTINATION_PATH_TOPIC_SUBDIRECTORY = "etl.destination.path.topic.sub.dir";
     public static final String ETL_RUN_MOVE_DATA = "etl.run.move.data";
     public static final String ETL_RUN_TRACKING_POST = "etl.run.tracking.post";
@@ -112,6 +114,14 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
 
     public static Path getDestinationPath(JobContext job) {
         return new Path(job.getConfiguration().get(ETL_DESTINATION_PATH));
+    }
+
+    public static void setDestPathTopicDirOverride(JobContext job, String topicDirOverride) {
+        job.getConfiguration().set(ETL_DESTINATION_PATH_TOPIC_DIR_OVERRIDE, topicDirOverride);
+    }
+
+    public static String getDestPathTopicDirOverride(JobContext job) {
+        return job.getConfiguration().get(ETL_DESTINATION_PATH_TOPIC_DIR_OVERRIDE);
     }
 
     public static void setDestPathTopicSubDir(JobContext job, String subPath) {

--- a/camus-example/pom.xml
+++ b/camus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camus-example</artifactId>

--- a/camus-schema-registry-avro/pom.xml
+++ b/camus-schema-registry-avro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camus-schema-registry-avro</artifactId>

--- a/camus-schema-registry/pom.xml
+++ b/camus-schema-registry/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camus-schema-registry</artifactId>

--- a/camus-sweeper/dependency-reduced-pom.xml
+++ b/camus-sweeper/dependency-reduced-pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>camus-parent</artifactId>
     <groupId>com.linkedin.camus</groupId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.linkedin.camus</groupId>
   <artifactId>camus-sweeper</artifactId>
   <name>Camus compaction code small files produced Camus</name>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.4.0-SNAPSHOT</version>
   <build>
     <finalName>${project.artifactId}-${project.version}</finalName>
     <plugins>

--- a/camus-sweeper/pom.xml
+++ b/camus-sweeper/pom.xml
@@ -4,12 +4,12 @@
 	<groupId>com.linkedin.camus</groupId>
 	<artifactId>camus-sweeper</artifactId>
 	<name>Camus compaction code small files produced Camus</name>
-	<version>0.3.0-SNAPSHOT</version>
-	
+	<version>0.4.0-SNAPSHOT</version>
+
 	<parent>
 		<groupId>com.linkedin.camus</groupId>
 		<artifactId>camus-parent</artifactId>
-		<version>0.3.0-SNAPSHOT</version>
+		<version>0.4.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Camus Parent</name>
     <description>
@@ -30,17 +30,17 @@
             <dependency>
                 <groupId>com.linkedin.camus</groupId>
                 <artifactId>camus-api</artifactId>
-                <version>0.3.0-SNAPSHOT</version>
+                <version>0.4.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.linkedin.camus</groupId>
                 <artifactId>camus-etl-kafka</artifactId>
-                <version>0.3.0-SNAPSHOT</version>
+                <version>0.4.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.linkedin.camus</groupId>
                 <artifactId>camus-kafka-coders</artifactId>
-                <version>0.3.0-SNAPSHOT</version>
+                <version>0.4.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.minidev</groupId>
@@ -50,12 +50,12 @@
             <dependency>
                 <groupId>com.linkedin.camus</groupId>
                 <artifactId>camus-schema-registry</artifactId>
-                <version>0.3.0-SNAPSHOT</version>
+                <version>0.4.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.linkedin.camus</groupId>
                 <artifactId>camus-schema-registry</artifactId>
-                <version>0.3.0-SNAPSHOT</version>
+                <version>0.4.0-SNAPSHOT</version>
                 <type>test-jar</type>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
The DefaultPartitioner places partition dirs under `topic-name`, this config allows us to specify an override dir for all topics.

Tested behavior with and without override on sample data from kafka. Output paths are as expected in both cases.
